### PR TITLE
Add "rel='author'" to postheader

### DIFF
--- a/library/filters.php
+++ b/library/filters.php
@@ -35,7 +35,7 @@ function arras_postheader() {
 		$postheader .= '<div class="entry-info">';
 	
 		if ( arras_get_option('post_author') ) {
-			$postheader .= sprintf( __('<div class="entry-author">By %s</div>', 'arras'), '<address class="author vcard"><a class="url fn n" href="' . get_author_posts_url( get_the_author_meta('ID') ) . '" title="' . esc_attr(get_the_author()) . '">' . get_the_author() . '</a></address>' );
+			$postheader .= sprintf( __('<div class="entry-author">By %s</div>', 'arras'), '<address class="author vcard"><a class="url fn n" href="' . get_author_posts_url( get_the_author_meta('ID') ) . '" rel="author" title="' . esc_attr(get_the_author()) . '">' . get_the_author() . '</a></address>' );
 		}
 		
 		if ( arras_get_option('post_date') ) {


### PR DESCRIPTION
This is a fix for Issue 168 on Google Code (http://code.google.com/p/arras-theme/issues/detail?id=168).

The description was the following:

In filter.php in the folder library, the arras_postheader() should add rel="author" to the Author information line. This is coming from the HTML5 Guidelines for identifying content, e.g. described here: https://support.google.com/webmasters/bin/answer.py?answer=1229920
